### PR TITLE
docs: Fix a few typos

### DIFF
--- a/utilities_and_data/plot_tools.py
+++ b/utilities_and_data/plot_tools.py
@@ -168,7 +168,7 @@ def hist_multi_sharex(
         the samples to be plotted
 
     rowlabels : sequence of str, optional
-        Names for the rows, by defalut no name labels are used.
+        Names for the rows, by default no name labels are used.
 
     n_bins : int, optional
         number of bins in the whole plot range
@@ -186,7 +186,7 @@ def hist_multi_sharex(
         the histograms is plotted.
 
     x_line_colors : sequence of colors or color, optional
-        Respective line colors for each `x_line`. Defalut color is ``'C1'``.
+        Respective line colors for each `x_line`. Default color is ``'C1'``.
 
     Returns
     -------
@@ -230,7 +230,7 @@ def hist_multi_sharex(
         ax.spines['right'].set_visible(False)
         ax.set_yticks(())
 
-    # draw lines accross all the figures
+    # draw lines across all the figures
     if x_lines is not None:
         # ensure sequences provided
         if np.isscalar(x_lines):

--- a/utilities_and_data/psis.py
+++ b/utilities_and_data/psis.py
@@ -13,7 +13,7 @@ psislw
     Pareto smoothed importance sampling.
 
 gpdfitnew
-    Estimate the paramaters for the Generalized Pareto Distribution (GPD).
+    Estimate the parameters for the Generalized Pareto Distribution (GPD).
 
 gpinv
     Inverse Generalised Pareto distribution function.
@@ -72,7 +72,7 @@ def psisloo(log_lik, **kwargs):
     likelihood terms :math:`p(y_i|\theta^s)` in input parameter `log_lik`.
     Returns a sum of the leave-one-out log predictive densities `loo`,
     individual leave-one-out log predictive density terms `loos` and an estimate
-    of Pareto tail indeces `ks`. If tail index k > 0.5, variance of the raw
+    of Pareto tail indices `ks`. If tail index k > 0.5, variance of the raw
     estimate does not exist and if tail index k > 1 the mean of the raw estimate
     does not exist and the PSIS estimate is likely to have large variation and
     some bias.
@@ -95,7 +95,7 @@ def psisloo(log_lik, **kwargs):
         individual leave-one-out log predictive density terms
 
     ks : ndarray
-        estimated Pareto tail indeces
+        estimated Pareto tail indices
 
     """
     # ensure overwrite flag in passed arguments
@@ -211,7 +211,7 @@ def psislw(lw, wcpp=20, wtrunc=3/4, overwrite_lw=False):
 
 
 def gpdfitnew(x, sort=True, sort_in_place=False):
-    """Estimate the paramaters for the Generalized Pareto Distribution (GPD)
+    """Estimate the parameters for the Generalized Pareto Distribution (GPD)
 
     Returns empirical Bayes estimate for the parameters of the two-parameter
     generalized Parato distribution given the data.

--- a/utilities_and_data/psrf.py
+++ b/utilities_and_data/psrf.py
@@ -23,7 +23,7 @@ def psrf(X, return_extra=False):
        convergence of iterative simulations. Journal of Computational and 
        Graphical Statistics. 7, 434-455. 
     Current version:
-       Split chains, return square-root definiton of R, and compute n_eff using 
+       Split chains, return square-root definition of R, and compute n_eff using 
        variogram estimate and Geyer's initial positive sequence as described in 
        Gelman et al (2013), Bayesian Data Analsyis, 3rd ed, sections 11.4-11.5.
     


### PR DESCRIPTION
There are small typos in:
- utilities_and_data/plot_tools.py
- utilities_and_data/psis.py
- utilities_and_data/psrf.py

Fixes:
- Should read `parameters` rather than `paramaters`.
- Should read `indices` rather than `indeces`.
- Should read `definition` rather than `definiton`.
- Should read `default` rather than `defalut`.
- Should read `across` rather than `accross`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md