### PR TITLE
Notebook testing in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,35 @@
+name: CI
+
+on: [ push, pull_request ]
+
+jobs:
+  test:
+    name: Testing
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.6'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-${{ env.pythonLocation }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ env.pythonLocation }}-pip-
+      - uses: FedericoCarboni/setup-ffmpeg@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+        id: setup-ffmpeg
+      - name: Install dependencies
+        run: |
+          pip install wheel pytest pytest-xdist nbval
+          pip install -r requirements.txt
+      - name: Run tests
+        run: pytest -n 2 --junitxml=test_report.xml --nbval-lax . --dist loadscope
+      - name: Upload test results
+        if: always()
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          files: ./test_report.xml
+          check_name: Test results

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 matplotlib==2.0.2
-numpy==1.13.1
+numpy==1.16.0
 numpydoc==0.6.0
 pandas==0.20.3
 pystan==2.16.0.0
 scipy==0.19.1
 seaborn==0.8
+arviz==0.1


### PR DESCRIPTION
This PR adds testing of notebooks to GitHub Actions (CI). The notebooks are tested to run w/o errors (output is not checked) using `nbval`.

The CI has caching and shows test results in workflow and PRs using [EnricoMi/publish-unit-test-result-action@v1](https://github.com/EnricoMi/publish-unit-test-result-action)

Additionally, NumPy is updated to 1.16 because I couldn't get Arviz to work with the mentioned version.
